### PR TITLE
Modify and return a cloned copy of route file instead of original (v 2.1.0)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs')
 const path = require('path')
+const _ = require('lodash')
 
 /**
  * Load all the route files and add the routes to the express app
@@ -19,13 +20,40 @@ function loader (routeDir, prefix) {
   return routes
 }
 
+/**
+ * Reads all route files within the directory/subdirectory
+ * Imports each route file, makes a clone of it, and then
+ * modifies the route.url of the clone accordingly.
+ * This clone is returned so as to preserve the original route file
+ * @param  {String} dirname     Directory name (ex: /path/to/application/routes)
+ * @param  {String} basedirname Sub path within dirname folder (ex: 'v1')
+ * @param  {String} prefix      Route prefix passed to loader (ex: '/api/config')
+ * @return {Object[]}           Array of Route Objects, of the form:
+  [
+    {
+      method: 'get',
+      url: '/api/config/v1/configs/,
+      description: 'Get a list of configs',
+      handler: [Function: deleteConfig], //  the handling function to call
+      tags: ['configs'],
+      validate: {
+        params: {...}
+      },
+      response: {
+        status: {...}
+      }
+    },
+    {...}
+  ]
+ */
 function _readDirectory (dirname, basedirname, prefix) {
   prefix = prefix || ''
 
   return fs.readdirSync(dirname)
     .filter((item) => fs.lstatSync(path.resolve(dirname, item)).isFile())
     .reduce((acc, file) => {
-      const routes = require(path.resolve(dirname, file))
+      const filePath = path.resolve(dirname, file)
+      const routes = _.cloneDeep(require(filePath))
 
       return acc.concat(routes.map((route) => {
         route.url = `/${prefix}/${/^_root$/.test(basedirname) ? '' : basedirname}/${route.url}/`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "route4express",
+  "version": "2.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://artifactory.ubisoft.org/api/npm/npm-gap/lodash/-/lodash-4.17.11.tgz?dl=https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "route4express",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Route 4 express",
   "main": "lib/index.js",
   "scripts": {
@@ -24,12 +24,14 @@
     "url": "https://github.com/ggstalder/route4express/issues"
   },
   "homepage": "https://github.com/ggstalder/route4express#readme",
-  "peerDependencies": {
-  },
+  "peerDependencies": {},
   "devDependencies": {
     "standard": "^10.0.2"
   },
   "standard": {
     "env": "mocha"
+  },
+  "dependencies": {
+    "lodash": "^4.17.11"
   }
 }


### PR DESCRIPTION
Fixes a bug where if you call route4express twice, the 2nd time returns corrupted routes (route.url is bad as the concatenation is done twice)
